### PR TITLE
Netusersam/tim 56 fix formatting for all day events

### DIFF
--- a/components/EventCard.tsx
+++ b/components/EventCard.tsx
@@ -25,6 +25,7 @@ import {
   showMultipleDays,
   endsNextDayBeforeMorning,
   timeFormat,
+  eventTimesAreDefined,
 } from "@/lib/utils";
 import { AddToCalendarButtonProps } from "@/types";
 import { SimilarityDetails } from "@/lib/similarEvents";
@@ -126,9 +127,15 @@ function EventDetails({
       </ConditionalWrapper>
       <div className="p-1"></div>
       <div className="flex gap-2">
-        <div className="shrink-0 items-center rounded-md bg-gray-50 px-2 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10">
-          {timeFormat(startTime)}-{timeFormat(endTime)}
-        </div>
+        <ConditionalWrapper
+          condition={eventTimesAreDefined(startTime, endTime)}
+          wrapper={() => (
+            <div className="shrink-0 items-center rounded-md bg-gray-50 px-2 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10">
+              {timeFormat(startTime)}-{timeFormat(endTime)}
+            </div>
+          )}
+        ></ConditionalWrapper>
+
         {location && (
           <Link
             href={`https://www.google.com/maps/search/?api=1&query=${location}`}

--- a/components/EventCardNew.tsx
+++ b/components/EventCardNew.tsx
@@ -25,6 +25,7 @@ import {
   cn,
   showMultipleDays,
   endsNextDayBeforeMorning,
+  eventTimesAreDefined,
   timeFormat,
 } from "@/lib/utils";
 import { AddToCalendarButtonProps } from "@/types";
@@ -113,6 +114,7 @@ function EventDateDisplaySimple({
   const showMultiDay = showMultipleDays(startDateInfo, endDateInfo);
   const showNightIcon =
     endsNextDayBeforeMorning(startDateInfo, endDateInfo) && !showMultiDay;
+  const showTimeRange = eventTimesAreDefined(startTime, endTime);
 
   if (!startDateInfo || !endDateInfo) {
     console.error("startDateInfo or endDateInfo is missing");
@@ -125,12 +127,13 @@ function EventDateDisplaySimple({
     .substring(0, 3)
     .toUpperCase()} ${startDateInfo.day}`;
 
-  const formattedTimes = `${timeFormat(startTime)}-${timeFormat(endTime)}`;
-
+  const formattedTimes = showTimeRange
+    ? `${timeFormat(startTime)}-${timeFormat(endTime)}`
+    : "";
   return (
     <span>
       {formattedStartDate} {formattedTimes}
-      {showNightIcon && "🌛"}
+      {showTimeRange && showNightIcon && "🌛"}
     </span>
   );
 }

--- a/lib/utils.tsx
+++ b/lib/utils.tsx
@@ -288,6 +288,10 @@ export function endsNextDayBeforeMorning(
   return isNextDay && isBeforeMorning;
 }
 
+export function eventTimesAreDefined(startTime: string, endTime: string) {
+  return startTime != undefined && endTime != undefined;
+}
+
 export function spansMultipleDays(
   startDateInfo: DateInfo | null,
   endDateInfo: DateInfo | null


### PR DESCRIPTION
the pull request that I have up essentially does not display a time range if there was never one provided - in a separate issue we can allow for an all day conditional wrapper to be added to the all events page and the single event page - but there should probably be a check box on the form that allows for an “all-day event” submission - feel free to check out the pull request and let me know what you think